### PR TITLE
feat(frontend): #126 comment box displayed for internal users on the Aquifer Summary page

### DIFF
--- a/frontend/src/aquifers/components/View.vue
+++ b/frontend/src/aquifers/components/View.vue
@@ -262,8 +262,8 @@
                 :loading="loadingFiles"
                 v-on:fetchFiles="fetchFiles">
               </aquifer-documents>
-              <div v-if="$keycloak.authenticated">
-                <h5 class="mt-5 border-bottom pb-4 main-title">Internal Comments</h5>
+              <div v-if="isAuthenticated">
+                <h5 class="mt-5 border-bottom pb-4 main-title" id="internal-comments-title">Internal Comments</h5>
                 <b-col cols="6" md="3" lg="6" id="aquifer-notes">{{record.notes}}</b-col>
                 <p v-if="!record.notes">
                   No internal comments available for this aquifer.
@@ -623,7 +623,7 @@ export default {
     }
   },
   computed: {
-    ...mapGetters(['userRoles']),
+    ...mapGetters(['userRoles', 'keycloak']),
     ...mapGetters('aquiferStore/view', {
       uncorrelatedWells: 'wellsWithoutAquiferCorrelation'
     }),
@@ -648,6 +648,9 @@ export default {
     ...mapState('aquiferStore/view', {
       storedId: 'id'
     }),
+    isAuthenticated() {
+      return this.$keycloak && this.$keycloak.authenticated;
+    },
     id () { return parseInt(this.$route.params.id) || null },
     editMode () { return this.edit },
     viewMode () { return !this.edit },

--- a/frontend/src/aquifers/components/View.vue
+++ b/frontend/src/aquifers/components/View.vue
@@ -262,7 +262,7 @@
                 :loading="loadingFiles"
                 v-on:fetchFiles="fetchFiles">
               </aquifer-documents>
-              <div v-if="isAuthenticated">
+              <div v-if="userRoles.aquifers.view">
                 <h5 class="mt-5 border-bottom pb-4 main-title" id="internal-comments-title">Internal Comments</h5>
                 <b-col cols="6" md="3" lg="6" id="aquifer-notes">{{record.notes}}</b-col>
                 <p v-if="!record.notes">
@@ -648,9 +648,6 @@ export default {
     ...mapState('aquiferStore/view', {
       storedId: 'id'
     }),
-    isAuthenticated() {
-      return this.$keycloak && this.$keycloak.authenticated;
-    },
     id () { return parseInt(this.$route.params.id) || null },
     editMode () { return this.edit },
     viewMode () { return !this.edit },

--- a/frontend/src/aquifers/components/View.vue
+++ b/frontend/src/aquifers/components/View.vue
@@ -623,7 +623,7 @@ export default {
     }
   },
   computed: {
-    ...mapGetters(['userRoles', 'keycloak']),
+    ...mapGetters(['userRoles']),
     ...mapGetters('aquiferStore/view', {
       uncorrelatedWells: 'wellsWithoutAquiferCorrelation'
     }),

--- a/frontend/src/aquifers/components/View.vue
+++ b/frontend/src/aquifers/components/View.vue
@@ -262,6 +262,13 @@
                 :loading="loadingFiles"
                 v-on:fetchFiles="fetchFiles">
               </aquifer-documents>
+              <div v-if="$keycloak.authenticated">
+                <h5 class="mt-5 border-bottom pb-4 main-title">Internal Comments</h5>
+                <b-col cols="6" md="3" lg="6" id="aquifer-notes">{{record.notes}}</b-col>
+                <p v-if="!record.notes">
+                  No internal comments available for this aquifer.
+                </p>
+              </div>
             </b-col>
             <b-col cols="12" xl="4" lg="6">
               <h5 class="mt-3 border-bottom pb-4 main-title">Licensing Information</h5>

--- a/frontend/src/common/store/auth.js
+++ b/frontend/src/common/store/auth.js
@@ -16,7 +16,7 @@ const auth = {
     userRoles (state) {
       if (state.keycloak && state.keycloak.authenticated) {
         // map SSO roles to web app permissions
-        // IMPORTANT: One should be relying on SSO composite roles (which can be found alongside all of the 
+        // IMPORTANT: One should be relying on SSO composite roles (which can be found alongside all of the
         // granular roles on Common Hosted SSO) to assign the appropriate roles.
         // e.g. We don't need to understand what a Statutory Authority is here, we should
         // only be concerned if the right to edit/approve is set. It's up to keycloak to associate some
@@ -27,7 +27,7 @@ const auth = {
         // even if the user does have that role.
         // Instead, we have to look at the "raw" list of roles contained inside the keycloak instance.
         const clientRoles = state.keycloak.idTokenParsed['client_roles']
-        return {          
+        return {
           registry: {
             view: clientRoles.includes('registries_viewer'),
             edit: clientRoles.includes('registries_edit'),
@@ -45,7 +45,8 @@ const auth = {
             approve: clientRoles.includes('wells_approve')
           },
           aquifers: {
-            edit: clientRoles.includes('aquifers_edit')
+            edit: clientRoles.includes('aquifers_edit'),
+            view: clientRoles.includes('aquifers_view')
           },
           surveys: {
             edit: clientRoles.includes('surveys_edit')

--- a/frontend/tests/unit/specs/aquifers/components/__snapshots__/View.spec.js.snap
+++ b/frontend/tests/unit/specs/aquifers/components/__snapshots__/View.spec.js.snap
@@ -677,6 +677,8 @@ exports[`View Component View mode matches the snapshot 1`] = `
                 id="4"
                 publicfilestitle="Other Documents"
               />
+               
+              <!---->
             </div>
              
             <div


### PR DESCRIPTION
# Description

New heading for internal comments and now showing comments for internal users on the Aquifer Summary page when an aquifer is selected.

Fixes # (issue)

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Authorized users can view internal comments
- [x] Unauthorized users can't view comments
- [x] Updated snapshot on existing test


## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

Unauthorized user
![Screenshot 2024-10-30 at 2 22 14 PM](https://github.com/user-attachments/assets/2dea8e21-3cc9-4ed9-bf75-4560a01b7441)

Authorized User with a comment on aquifer
![Screenshot 2024-10-30 at 2 40 21 PM](https://github.com/user-attachments/assets/5acdf57d-63a9-4f7c-9f45-3f119ea34cc0)

Authorized User without a comment on aquifer
![Screenshot 2024-10-30 at 2 22 40 PM](https://github.com/user-attachments/assets/138d93a0-d86e-4a04-981c-69a62fe83433)



---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-gwells-125-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-gwells-125-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-gwells/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-gwells/actions/workflows/merge.yml)