### PR TITLE
feat(frontend): added internal comments to well details

### DIFF
--- a/frontend/src/wells/views/WellDetail.vue
+++ b/frontend/src/wells/views/WellDetail.vue
@@ -124,6 +124,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
                 <div><a class="jump_link" href="#well_yield_fieldset">Well Yield</a></div>
                 <div><a class="jump_link" href="#well_decommissioning_fieldset">Well Decommissioning</a></div>
                 <div><a class="jump_link" href="#well_comments_fieldset">Comments</a></div>
+                <div v-if="isAuthenticated"><a class="jump_link" href="#well_internal_comments_fieldset">Internal Comments</a></div>
                 <div v-if="config && config.enable_documents"><a class="jump_link" href="#documents_fieldset">Documentation</a></div>
                 <div><a class="jump_link" href="#disclaimer_fieldset">Disclaimer</a></div>
               </b-col>
@@ -496,7 +497,8 @@ Licensed under the Apache License, Version 2.0 (the "License");
                   { key: 'specific_yield', label: 'Specific Yield' },
                   { key: 'specific_capacity', label: 'Specific Capacity (L/s/m)' },
                   { key: 'analysis_method', label: 'Analysis Method' },
-                  { key: 'comments', label: 'Comments' }
+                  { key: 'comments', label: 'Comments' },
+                  { key: 'internal_comments', label: 'Internal Comments' }
                 ]"
                 show-empty>
                 <template v-slot:head(pumping_test_description)="data">
@@ -553,6 +555,13 @@ Licensed under the Apache License, Version 2.0 (the "License");
           <legend>Comments</legend>
           <p>
             {{ well.comments ? well.comments : 'No comments submitted' }}
+          </p>
+        </fieldset>
+
+        <fieldset id="well_internal_comments_fieldset" class="my-3 detail-section" v-if="isAuthenticated">
+          <legend>Internal Comments</legend>
+          <p>
+            {{ well.internalComments ? well.internalComments : 'No internal comments submitted' }}
           </p>
         </fieldset>
 
@@ -673,7 +682,10 @@ export default {
     isUnpublished () {
       return !this.well.is_published
     },
-    ...mapGetters(['userRoles', 'config', 'well', 'wellLicence', 'storedWellId', 'codes'])
+    isAuthenticated() {
+      return this.$keycloak && this.$keycloak.authenticated
+    },
+    ...mapGetters(['userRoles', 'config', 'well', 'wellLicence', 'storedWellId', 'codes', 'keycloak'])
   },
   methods: {
     handlePrint () {

--- a/frontend/src/wells/views/WellDetail.vue
+++ b/frontend/src/wells/views/WellDetail.vue
@@ -683,9 +683,9 @@ export default {
       return !this.well.is_published
     },
     isAuthenticated() {
-      return this.$keycloak && this.$keycloak.authenticated
+      return this.userRoles.wells && this.userRoles.wells.view
     },
-    ...mapGetters(['userRoles', 'config', 'well', 'wellLicence', 'storedWellId', 'codes', 'keycloak'])
+    ...mapGetters(['userRoles', 'config', 'well', 'wellLicence', 'storedWellId', 'codes'])
   },
   methods: {
     handlePrint () {

--- a/frontend/src/wells/views/WellDetail.vue
+++ b/frontend/src/wells/views/WellDetail.vue
@@ -124,7 +124,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
                 <div><a class="jump_link" href="#well_yield_fieldset">Well Yield</a></div>
                 <div><a class="jump_link" href="#well_decommissioning_fieldset">Well Decommissioning</a></div>
                 <div><a class="jump_link" href="#well_comments_fieldset">Comments</a></div>
-                <div v-if="isAuthenticated"><a class="jump_link" href="#well_internal_comments_fieldset">Internal Comments</a></div>
+                <div v-if="hasViewRole"><a class="jump_link" href="#well_internal_comments_fieldset">Internal Comments</a></div>
                 <div v-if="config && config.enable_documents"><a class="jump_link" href="#documents_fieldset">Documentation</a></div>
                 <div><a class="jump_link" href="#disclaimer_fieldset">Disclaimer</a></div>
               </b-col>
@@ -558,7 +558,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
           </p>
         </fieldset>
 
-        <fieldset id="well_internal_comments_fieldset" class="my-3 detail-section" v-if="isAuthenticated">
+        <fieldset id="well_internal_comments_fieldset" class="my-3 detail-section" v-if="hasViewRole">
           <legend>Internal Comments</legend>
           <p>
             {{ well.internalComments ? well.internalComments : 'No internal comments submitted' }}
@@ -682,7 +682,7 @@ export default {
     isUnpublished () {
       return !this.well.is_published
     },
-    isAuthenticated() {
+    hasViewRole() {
       return this.userRoles.wells && this.userRoles.wells.view
     },
     ...mapGetters(['userRoles', 'config', 'well', 'wellLicence', 'storedWellId', 'codes'])


### PR DESCRIPTION
# Description

Code change for a user story regarding seeing Internal Comments when signed in. No changes to existing elements on the Well Summary page.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I tested this manually when logged in and not logged in. They were shown when I was logged in and omitted when I logged out. The internal comments populated correctly.


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-gwells-150-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-gwells-150-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-gwells/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-gwells/actions/workflows/merge.yml)