### PR TITLE
fix: hide internal well comments from public users

### DIFF
--- a/backend/wells/fixtures/well_detail_fixture.json
+++ b/backend/wells/fixtures/well_detail_fixture.json
@@ -55,6 +55,7 @@
               "utm_easting": null,
               "well_location_description": "",
               "comments": null,
+              "internal_comments": null,
               "well_identification_plate_attached": null,
               "well_yield_unit": null,
               "finished_well_depth": null,

--- a/backend/wells/serializers.py
+++ b/backend/wells/serializers.py
@@ -706,6 +706,7 @@ class WellDetailSerializer(AuditModelSerializer):
             "well_cap_type",
             "well_disinfected_status",
             "comments",
+            "internal_comments",
             "alternative_specs_submitted",
             "technical_report",
             "drinking_water_protection_area_ind",

--- a/backend/wells/tests/test_wells.py
+++ b/backend/wells/tests/test_wells.py
@@ -122,3 +122,31 @@ class TestWellHistory(APITestCase):
         url = reverse('well-history', kwargs={'well_id': 123, 'version': 'v1'})
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+class TestWellDetailAuthenticated(APITestCase):
+    # Tbh, I don't know if all of these fixtures are necessary but I don't feel like tracing through the code to find out
+    fixtures = ['gwells-codetables', 'wellsearch-codetables', 'wellsearch', 'registries', 'registries-codetables', 'well_detail_fixture']
+
+    def setUp(self):
+        roles = [WELLS_VIEWER_ROLE]
+        for role in roles:
+            Group.objects.get_or_create(name=role)
+        user, _created = User.objects.get_or_create(username='test')
+        user.profile.username = user.username
+        user.save()
+        roles_to_groups(user, roles)
+        self.client.force_authenticate(user)
+
+    def test_well_detail_authenticated(self):
+        url = reverse('well-detail', kwargs={'well_id': 123, 'version': 'v1'})
+        response = self.client.get(url)
+        self.assertTrue('internal_comments' in response.data)
+
+class TestWellDetailUnauthenticated(APITestCase):
+    # Same comment as above
+    fixtures = ['gwells-codetables', 'wellsearch-codetables', 'wellsearch', 'registries', 'registries-codetables', 'well_detail_fixture']
+
+    def test_well_detail_unauthenticated(self):
+        url = reverse('well-detail', kwargs={'well_id': 123, 'version': 'v1'})
+        response = self.client.get(url)
+        self.assertFalse('internal_comments' in response.data)

--- a/backend/wells/views.py
+++ b/backend/wells/views.py
@@ -119,8 +119,14 @@ class WellDetail(RetrieveAPIView):
             qs = Well.objects.all()
         else:
             qs = Well.objects.all().exclude(well_publication_status='Unpublished')
-
         return qs
+
+    def get(self, request, *args, **kwargs):
+        """ Removes internal-only fields for public user """
+        response = super().get(self, request, *args, **kwargs)
+        if not(request.user.groups.filter(name=WELLS_VIEWER_ROLE).exists()):
+            response.data.pop('internal_comments')
+        return response
 
 
 class WellStaffEditDetail(RetrieveAPIView):

--- a/frontend/src/wells/views/WellDetail.vue
+++ b/frontend/src/wells/views/WellDetail.vue
@@ -561,7 +561,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
         <fieldset id="well_internal_comments_fieldset" class="my-3 detail-section" v-if="hasViewRole">
           <legend>Internal Comments</legend>
           <p>
-            {{ well.internalComments ? well.internalComments : 'No internal comments submitted' }}
+            {{ well.internal_comments ? well.internal_comments : 'No internal comments submitted' }}
           </p>
         </fieldset>
 


### PR DESCRIPTION
# Description

Bug fix in FE where the wrong key was being checked.
Feature change in the BE to add internal_comments to the fields that the API returns, but to only return it conditionally. Users with the well_view role are able to see it.

Fixes # 190

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Added tests to test_wells.py
- Manually tested locally

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-gwells-193-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-gwells-193-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-gwells/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-gwells/actions/workflows/merge.yml)