### PR TITLE
chore(ci): actions moved to bcgov org

### DIFF
--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Initialize
-        uses: bcgov-nr/action-deployer-openshift@v3.0.1
+        uses: bcgov/action-deployer-openshift@v3.0.1
         with:
           oc_namespace: ${{ vars.OC_NAMESPACE }}
           oc_server: ${{ vars.OC_SERVER }}
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Deploy Minio
-        uses: bcgov-nr/action-deployer-openshift@v3.0.1
+        uses: bcgov/action-deployer-openshift@v3.0.1
         with:
           oc_namespace: ${{ vars.OC_NAMESPACE }}
           oc_server: ${{ vars.OC_SERVER }}
@@ -82,7 +82,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Database
-        uses: bcgov-nr/action-deployer-openshift@v3.0.1
+        uses: bcgov/action-deployer-openshift@v3.0.1
         with:
           oc_namespace: ${{ vars.OC_NAMESPACE }}
           oc_server: ${{ vars.OC_SERVER }}
@@ -107,7 +107,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Deploy Backend
-        uses: bcgov-nr/action-deployer-openshift@v3.0.1
+        uses: bcgov/action-deployer-openshift@v3.0.1
         with:
           oc_namespace: ${{ vars.OC_NAMESPACE }}
           oc_server: ${{ vars.OC_SERVER }}
@@ -152,7 +152,7 @@ jobs:
   #   runs-on: ubuntu-latest
   #   steps:
   #     - name: Deploy Frontend
-  #       uses: bcgov-nr/action-deployer-openshift@v3.0.1
+  #       uses: bcgov/action-deployer-openshift@v3.0.1
   #       with:
   #         oc_namespace: ${{ vars.OC_NAMESPACE }}
   #         oc_server: ${{ vars.OC_SERVER }}

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -40,7 +40,7 @@ jobs:
 #           - dir: frontend
 #             token: SONAR_TOKEN_FRONTEND
 #     steps:
-#       - uses: bcgov-nr/action-test-and-analyse@v1.2.1
+#       - uses: bcgov/action-test-and-analyse@v1.2.1
 #         with:
 #           commands: |
 #             npm ci

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -31,7 +31,7 @@ jobs:
       # Get PR number for squash merges to main
       - name: PR Number
         id: pr
-        uses: bcgov-nr/action-get-pr@v0.0.1
+        uses: bcgov/action-get-pr@v0.0.1
 
   deploys-test:
     name: TEST Deploys (${{ needs.init.outputs.pr }})

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -9,7 +9,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # https://github.com/bcgov-nr/action-builder-ghcr
+  # https://github.com/bcgov/action-builder-ghcr
   builds:
     name: Builds
     runs-on: ubuntu-latest
@@ -22,7 +22,7 @@ jobs:
             build_file: ./backend/Dockerfile
     timeout-minutes: 20
     steps:
-      - uses: bcgov-nr/action-builder-ghcr@v2.2.0
+      - uses: bcgov/action-builder-ghcr@v2.2.0
         with:
           keep_versions: 50
           build_context: ${{ matrix.build_context }}


### PR DESCRIPTION
Most of our actions have been moved from bcgov-nr to bcgov.  There are redirects to handle this, but here are updated paths anyway.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-gwells-238-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-gwells-238-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-gwells/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-gwells/actions/workflows/merge.yml)