### PR TITLE
chore(ci): use GH runner ubuntu-24.04

### DIFF
--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -22,7 +22,7 @@ jobs:
   init:
     name: Initialize
     environment: ${{ inputs.environment }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Initialize
         uses: bcgov-nr/action-deployer-openshift@v3.0.1
@@ -59,7 +59,7 @@ jobs:
     name: Minio
     needs: [ init ]
     environment: ${{ inputs.environment }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Deploy Minio
         uses: bcgov-nr/action-deployer-openshift@v3.0.1
@@ -79,7 +79,7 @@ jobs:
     name: Database
     needs: init
     environment: ${{ inputs.environment }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Database
         uses: bcgov-nr/action-deployer-openshift@v3.0.1
@@ -104,7 +104,7 @@ jobs:
     name: Backend
     needs: [ init, database ]
     environment: ${{ inputs.environment }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Deploy Backend
         uses: bcgov-nr/action-deployer-openshift@v3.0.1
@@ -149,7 +149,7 @@ jobs:
   #   name: Frontend
   #   needs: [ init, database, backend ]
   #   environment: ${{ inputs.environment }}
-  #   runs-on: ubuntu-latest
+  #   runs-on: ubuntu-24.04
   #   steps:
   #     - name: Deploy Frontend
   #       uses: bcgov-nr/action-deployer-openshift@v3.0.1

--- a/.github/workflows/.tests.yml
+++ b/.github/workflows/.tests.yml
@@ -22,14 +22,14 @@ env:
 jobs:
   tests:
     name: Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: TODO Tests
         run: echo "The automated test suite is not set up yet."
         
   # integration-tests:
   #   name: Integration
-  #   runs-on: ubuntu-latest
+  #   runs-on: ubuntu-24.04
   #   timeout-minutes: 1
   #   steps:
   #     - uses: actions/checkout@v4
@@ -56,7 +56,7 @@ jobs:
   #   defaults:
   #     run:
   #       working-directory: frontend
-  #   runs-on: ubuntu-latest
+  #   runs-on: ubuntu-24.04
   #   timeout-minutes: 5
   #   strategy:
   #     matrix:
@@ -92,7 +92,7 @@ jobs:
 
   # load-tests:
   #   name: Load
-  #   runs-on: ubuntu-latest
+  #   runs-on: ubuntu-24.04
   #   strategy:
   #     matrix:
   #       name: [backend, frontend]

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -17,7 +17,7 @@ jobs:
 #   tests:  
 #     name: Tests
 #     if: ${{ ! github.event.pull_request.draft }}
-#     runs-on: ubuntu-latest
+#     runs-on: ubuntu-24.04
 #     timeout-minutes: 5
 #     services:
 #       postgres:
@@ -61,7 +61,7 @@ jobs:
   trivy:
     name: Trivy Security Scan
     if: ${{ ! github.event.pull_request.draft }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
@@ -85,7 +85,7 @@ jobs:
     # needs: [tests, trivy]
     needs: [trivy]
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - if: contains(needs.*.result, 'failure')||contains(needs.*.result, 'canceled')
         run: echo "At least one job has failed." && exit 1

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -25,7 +25,7 @@ jobs:
     name: Set Variables
     outputs:
       pr: ${{ steps.pr.outputs.pr }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 1
     steps:
       # Get PR number for squash merges to main
@@ -56,7 +56,7 @@ jobs:
   promote:
     name: Promote Images
     needs: [init, deploys-prod]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         package: [minio, database, backend, frontend]

--- a/.github/workflows/pr-labeler.yaml
+++ b/.github/workflows/pr-labeler.yaml
@@ -6,7 +6,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - uses: actions/labeler@v5

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -12,7 +12,7 @@ jobs:
   # https://github.com/bcgov-nr/action-builder-ghcr
   builds:
     name: Builds
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         package: [database, backend, frontend, minio]
@@ -50,6 +50,6 @@ jobs:
     name: PR Results
     needs: [builds, deploys, tests]
     if: always() && (!failure()) && (!cancelled())
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - run: echo "Success!"

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -22,6 +22,6 @@ jobs:
     name: Validate Results
     if: always()
     needs: [validate]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - run: echo "Success!"


### PR DESCRIPTION
GitHub runner ubuntu-latest is being updated from 22.04 to 24.04.  This uses an explicit version, which is better for consistency and predictability.